### PR TITLE
chore: switch renovatebot to weekly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:best-practices",
     ":separateMultipleMajorReleases",
-    "schedule:daily"
+    "schedule:weekly"
   ],
   "commitMessageSuffix": " in {{packageFile}}",
   "dependencyDashboardAutoclose": true,


### PR DESCRIPTION
## what

- change frequency to weekly

## why 
- renovatebot is too noisy these days

