### PR TITLE
Fix/guacamole sockets

### DIFF
--- a/tectonic/services/bastion_host/templates/tectonic.j2
+++ b/tectonic/services/bastion_host/templates/tectonic.j2
@@ -22,7 +22,7 @@
         ProxyPassReverse "https://{{ services.guacamole.ip }}:{{ services.guacamole.internal_port }}/"
     </Location>
 
-    <Location "/guacamole/websocket-tunnel/">
+    <Location "/guacamole/websocket-tunnel">
         ProxyPass "wss://{{ services.guacamole.ip }}:{{ services.guacamole.internal_port }}/websocket-tunnel"
         ProxyPassReverse "wss://{{ services.guacamole.ip }}:{{ services.guacamole.internal_port }}/websocket-tunnel"
     </Location>

--- a/tectonic/services/teacher_access_host/base_config.yml
+++ b/tectonic/services/teacher_access_host/base_config.yml
@@ -1,0 +1,28 @@
+#
+# Tectonic - An academic Cyber Range
+# Copyright (C) 2024 Grupo de Seguridad Informática, Universidad de la República,
+# Uruguay
+#
+# This file is part of Tectonic.
+#
+# Tectonic is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Tectonic is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Tectonic.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: "Install Teacher Access Host (Ubuntu 22.04)"
+  hosts: teacher_access_host
+  become: true
+  gather_facts: true
+  tasks:
+    - name: "Update repos"
+      ansible.builtin.apt:
+        update_cache: yes


### PR DESCRIPTION
Bug Fixes:

1. Guacamole wasn't using web sockets, which resulted in slower connections.

2. Packer fails if the machine doesn't have a base playbook to apply. I suspect that a plugin version upgrade broke the following part of the code:

playbook_file = (fileexists("${local.tectonic["ansible_dir"]}/base_config.yml") ?
  "${local.tectonic["ansible_dir"]}/base_config.yml":
   "/dev/null")

In particular, /dev/null can be used. As a workaround, I generated a playbook for the teacher_access_host service machine.